### PR TITLE
Smartgroup cache check

### DIFF
--- a/CRM/CivirulesConditions/Utils/GroupContact.php
+++ b/CRM/CivirulesConditions/Utils/GroupContact.php
@@ -28,6 +28,10 @@ class CRM_CivirulesConditions_Utils_GroupContact {
       // If the groups are smartgroups (saved searches) they may be out of date.
       // This triggers a check (and rebuild if necessary).
       \CRM_Contact_BAO_GroupContactCache::check($group_id);
+      // We query the cache table to check a row exists for the provided group and contact
+      // Any returned column/field is acceptable; we just want something returned.
+      // We return group_id rather than id as cache tables may not necessarily have an id column.
+      // cf. https://github.com/civicrm/civicrm-core/pull/9801
       $query = "SELECT group_id FROM `civicrm_group_contact_cache` WHERE group_id=%1 AND contact_id=%2";
       $queryParams = [
         1 => [$group_id, 'Positive'],

--- a/CRM/CivirulesConditions/Utils/GroupContact.php
+++ b/CRM/CivirulesConditions/Utils/GroupContact.php
@@ -19,7 +19,7 @@ class CRM_CivirulesConditions_Utils_GroupContact {
     ) {
       return FALSE;
     }
-    $query = "SELECT saved_search_id FROM `civicrm_group` WHERE group_id=%1";
+    $query = "SELECT saved_search_id FROM `civicrm_group` WHERE id=%1";
     $queryParams = [
       1 => [$group_id, 'Positive'],
     ];

--- a/CRM/CivirulesConditions/Utils/GroupContact.php
+++ b/CRM/CivirulesConditions/Utils/GroupContact.php
@@ -19,6 +19,24 @@ class CRM_CivirulesConditions_Utils_GroupContact {
     ) {
       return FALSE;
     }
+    $query = "SELECT saved_search_id FROM `civicrm_group` WHERE group_id=%1";
+    $queryParams = [
+      1 => [$group_id, 'Positive'],
+    ];
+    if (CRM_Core_DAO::singleValueQuery($query, $queryParams, FALSE)) {
+      // @fixme We really need a "is in smartgroup" API!!
+      // If the groups are smartgroups (saved searches) they may be out of date.
+      // This triggers a check (and rebuild if necessary).
+      \CRM_Contact_BAO_GroupContactCache::check($group_id);
+      $query = "SELECT group_id FROM `civicrm_group_contact_cache` WHERE group_id=%1 AND contact_id=%2";
+      $queryParams = [
+        1 => [$group_id, 'Positive'],
+        2 => [$contact_id, 'Positive'],
+      ];
+      if (CRM_Core_DAO::singleValueQuery($query, $queryParams, FALSE)) {
+        return TRUE;
+      }
+    }
     try {
       $groupContactCount = civicrm_api3('GroupContact', 'getcount', [
         'group_id' => $group_id,
@@ -29,20 +47,6 @@ class CRM_CivirulesConditions_Utils_GroupContact {
       return FALSE;
     }
     if ($groupContactCount > 0) {
-      return TRUE;
-    }
-
-    // @fixme We really need a "is in smartgroup" API!!
-    // If the groups are smartgroups (saved searches) they may be out of date.
-    // This triggers a check (and rebuild if necessary).
-    \CRM_Contact_BAO_GroupContactCache::check($group_id);
-
-    $query = "SELECT group_id FROM `civicrm_group_contact_cache` WHERE group_id=%1 AND contact_id=%2";
-    $queryParams = [
-      1 => [$group_id, 'Positive'],
-      2 => [$contact_id, 'Positive'],
-    ];
-    if (CRM_Core_DAO::singleValueQuery($query, $queryParams, FALSE)) {
       return TRUE;
     }
 


### PR DESCRIPTION
This PR [backports a refactor of the GroupContact condition check in CiviRules](https://lab.civicrm.org/extensions/civirules/-/commit/fbc4ad963084ce5106e3007e7ad0339bb3fc342f). It improves the prior fix for the missing `id` column in the smart group contact cache table and makes the condition check slightly more performant overall.
